### PR TITLE
Corrected links

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,11 +2,11 @@
 
 The simplest way to obtain the code is using Github's .zip feature.
 
-Click [here](https://github.com/Baystation12/Baystation12/archive/dev.zip) to get the latest code as a .zip file, then unzip it to wherever you want.
+Click [here](https://github.com/Bibostation13/Bibostation13/archive/dev.zip) to get the latest code as a .zip file, then unzip it to wherever you want.
 
 The more complicated and easier to update method is using git.  You'll need to download git or some client from [here](http://git-scm.com/).  When that's installed, right click in any folder and click on "Git Bash".  When that opens, type in:
 
-    git clone https://github.com/Baystation12/Baystation12.git
+    git clone https://github.com/Bibostation13/Bibostation13.git
 
 (hint: hold down ctrl and press insert to paste into git bash)
 


### PR DESCRIPTION
Changed two (2) URLs to point to the BB13 repo instead of Bay's.
A few references to baystation remain (namely, the file 'baystation12.dme'), but seeing that they're not wrong for the purposes of this guide, they've been left as-is. For now.