### PR TITLE
Changed references to Baystation12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# baystation12 [![CI Status](https://github.com/Baystation12/Baystation12/workflows/Run%20Tests/badge.svg)](https://github.com/Baystation12/Baystation12/actions)
+# bibostation13 [![CI Status](https://github.com/Bibostation13/Bibostation13/workflows/Run%20Tests/badge.svg)](https://github.com/Bibostation13/Bibostation13/actions)
 
-[Website](https://baystation12.net/) - [Code](https://github.com/Baystation12/Baystation12/) - [Discord](https://discord.baystation12.net/) - [IRC](https://kiwiirc.com/client/irc.sorcery.net/codershuttle): irc://irc.sorcery.net/#codershuttle
+[Website (TBA)](https://to-be-added.soon/) | [Code](https://github.com/Bibostation13/Bibostation13/) | [Discord](https://discord.gg/xMRt7qMZ4n)
 
 ---
 


### PR DESCRIPTION
The Bibostation13 readme now talks about Bibostation13. Every relevant URL gets a change. The website link is, for the moment, a placeholder.
I haven't touched the licenses section, though. I don't know nearly enough to venture anywhere near that stuff, so somebody who _does_ should give it a read.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->