### PR TITLE
Fix skill panel focus loss upon button click

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -397,7 +397,7 @@ client/verb/character_setup()
 	set name = "Character Setup"
 	set category = "OOC"
 	if(prefs)
-		prefs.ShowChoices(usr)
+		prefs.open_setup_window(usr)
 
 /client/proc/apply_fps(var/client_fps)
 	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)

--- a/code/modules/client/preference_setup/global/03_pai.dm
+++ b/code/modules/client/preference_setup/global/03_pai.dm
@@ -47,6 +47,7 @@
 /datum/category_item/player_setup_item/player_global/pai/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["option"])
 		var/t
+		. = TOPIC_REFRESH
 		switch(href_list["option"])
 			if("name")
 				t = sanitizeName(input(user, "Enter a name for your pAI", "Global Preference", candidate.name) as text|null, MAX_NAME_LEN, 1)

--- a/code/modules/client/preference_setup/global/03_pai.dm
+++ b/code/modules/client/preference_setup/global/03_pai.dm
@@ -68,13 +68,15 @@
 			if("chassis")
 				candidate.chassis = input(user,"What would you like to use for your mobile chassis icon?") as null|anything in GLOB.possible_chassis
 				update_pai_preview(user)
+				. = TOPIC_HARD_REFRESH
 			if("say")
 				candidate.say_verb = input(user,"What theme would you like to use for your speech verbs?") as null|anything in GLOB.possible_say_verbs
 			if("cyclebg")
 				bgstate = next_in_list(bgstate, bgstate_options)
 				update_pai_preview(user)
+				. = TOPIC_HARD_REFRESH
 
-		return TOPIC_REFRESH
+		return
 
 	return ..()
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -375,6 +375,7 @@
 		update_skill_value(J, S, value)
 		panel.set_content(generate_skill_content(J))
 		panel.open()
+		return TOPIC_REFRESH
 
 	else if(href_list["skillinfo"])
 		var/decl/hierarchy/skill/S = locate(href_list["skillinfo"])

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -373,7 +373,6 @@
 			return
 		var/value = text2num(href_list["newvalue"])
 		update_skill_value(J, S, value)
-		pref.ShowChoices(user) //Manual refresh to allow us to focus the panel, not the main window.
 		panel.set_content(generate_skill_content(J))
 		panel.open()
 

--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -211,7 +211,7 @@
 	return JOINTEXT(dat)
 
 /datum/category_item/player_setup_item/occupation/proc/open_skill_setup(mob/user, datum/job/job)
-	panel = new(user, "Skill Selection: [job.title]", "Skill Selection: [job.title]", 770, 850, src)
+	panel = new(user, "skill-selection", "Skill Selection: [job.title]", 770, 850, src)
 	panel.set_content(generate_skill_content(job))
 	panel.open()
 

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -1,5 +1,6 @@
 #define TOPIC_UPDATE_PREVIEW 4
-#define TOPIC_REFRESH_UPDATE_PREVIEW (TOPIC_REFRESH|TOPIC_UPDATE_PREVIEW)
+#define TOPIC_HARD_REFRESH   8 // use to force a browse() call, unblocking some rsc operations
+#define TOPIC_REFRESH_UPDATE_PREVIEW (TOPIC_HARD_REFRESH|TOPIC_UPDATE_PREVIEW)
 
 var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 
@@ -109,7 +110,7 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 		. = 1
 
 	if(.)
-		user.client.prefs.ShowChoices(user)
+		user.client.prefs.update_setup_window(user)
 
 /**************************
 * Category Category Setup *
@@ -231,10 +232,12 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	if(!pref_mob || !pref_mob.client)
 		return 1
 
-	if(. & TOPIC_UPDATE_PREVIEW)
+	if (. & TOPIC_UPDATE_PREVIEW)
 		pref_mob.client.prefs.preview_icon = null
-	if(. & TOPIC_REFRESH)
-		pref_mob.client.prefs.ShowChoices(usr)
+	if (. & TOPIC_HARD_REFRESH)
+		pref_mob.client.prefs.open_setup_window(usr)
+	else if (. & TOPIC_REFRESH)
+		pref_mob.client.prefs.update_setup_window(usr)
 
 /datum/category_item/player_setup_item/CanUseTopic(var/mob/user)
 	return 1

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -91,7 +91,7 @@
 		return TOPIC_NOACTION
 
 	if(href_list["show_preferences"])
-		client.prefs.ShowChoices(src)
+		client.prefs.open_setup_window(src)
 		return 1
 
 	if(href_list["ready"])


### PR DESCRIPTION
🆑 afterthought, Mucker
bugfix: Fixes the skill panel refresh bug (for real this time).
/🆑

A port of the relevant [Bay PR](https://github.com/Baystation12/Baystation12/pull/30503).
Golly, I sure hope it works, because I have no idea if I did it right.

Made possible by one "afterthought", who is thanked in the original PR.
I thank him here on behalf of BB13, for good measure.

<!--
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Bibostation13/Bibostation13/wiki/Automatic-changelog-generation
-->
